### PR TITLE
Add permissions to be able to visit the root of the API gateway domain

### DIFF
--- a/authentication/start-auth-lambda/index.py
+++ b/authentication/start-auth-lambda/index.py
@@ -3,7 +3,7 @@ import json
 import base64
 import secrets
 from common.thalia_oauth import get_oauth2_client, AUTHORIZE_URL
-
+from common.discord_helper import DISCORD_GUILD_ID
 
 loop = asyncio.get_event_loop()
 
@@ -15,8 +15,9 @@ async def async_handle(event):
         discord_user = event.get("queryStringParameters", {}).get("discord-user", None)
         if not discord_user:
             return {
-                "statusCode": 400,
-                "body": "Error: Missing discord user",
+                "statusCode": 302,
+                "headers": {"Location": f"https://discord.com/channels/{DISCORD_GUILD_ID}"},
+                "body": "Missing discord user.",
             }
 
         random = secrets.token_bytes(64)

--- a/terraform/modules/authentication/main.tf
+++ b/terraform/modules/authentication/main.tf
@@ -115,5 +115,6 @@ module "start_auth_lambda" {
     THALIA_CLIENT_ID     = var.thalia_client_id
     THALIA_CLIENT_SECRET = var.thalia_client_secret
     OAUTH_REDIRECT_URI   = "https://${var.prefix}.${var.domain_name}/complete-auth"
+    DISCORD_GUILD_ID     = var.discord_guild_id
   }
 }

--- a/terraform/modules/authentication/modules/lambda/main.tf
+++ b/terraform/modules/authentication/modules/lambda/main.tf
@@ -40,8 +40,12 @@ module "lambda" {
 
   allowed_triggers = {
     AllowExecutionFromAPIGateway = {
-      service = "apigateway"
-      arn     = var.api_gateway_arn
+      service    = "apigateway"
+      source_arn = "${var.api_gateway_arn}/*/*/*"
+    },
+    AllowExecutionFromAPIGatewayRoot = {
+      service    = "apigateway"
+      source_arn = "${var.api_gateway_arn}/*/*"
     }
   }
 


### PR DESCRIPTION
This PR changes the config of the API Gateway to also allow calls to `https://discord-bot-develop.technicie.nl` instead of only `https://discord-bot-develop.technicie.nl/start-auth`.

Without the discord-user querystring parameter it will redirect you to the guild that is in the settings (currently Thalia test guild).