### PR TITLE
Fix complete authentication lambda by increasing timeout

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -16,9 +16,11 @@ if isdir("../common"):
 
 # pylint: disable=wrong-import-position
 from core.bot import ThaliaBot
-from common.bot_logger import get_logger
+from common.bot_logger import get_logger, configure_logging
 
 # pylint: enable=wrong-import-position
+
+configure_logging("bot.log")
 
 COGS_MODULE = "cogs"
 

--- a/common/bot_logger.py
+++ b/common/bot_logger.py
@@ -106,7 +106,7 @@ def configure_logging(name, level=None):
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     ch_debug.setFormatter(formatter_debug)
-    ch_debug.setLevel(logging.DEBUG)
+    ch_debug.setLevel(logging.WARNING)
 
     if level is not None:
         log_level = level

--- a/terraform/modules/authentication/main.tf
+++ b/terraform/modules/authentication/main.tf
@@ -2,6 +2,10 @@
 # HTTP API Gateway #
 ####################
 
+resource "aws_cloudwatch_log_group" "logs" {
+  name = "${var.prefix}-auth-api"
+}
+
 module "api_gateway" {
   source = "terraform-aws-modules/apigateway-v2/aws"
 
@@ -16,6 +20,9 @@ module "api_gateway" {
 
   domain_name                 = "${var.prefix}.${var.domain_name}"
   domain_name_certificate_arn = module.acm.this_acm_certificate_arn
+
+  default_stage_access_log_destination_arn = aws_cloudwatch_log_group.logs.arn
+  default_stage_access_log_format          = "$context.identity.sourceIp - $context.requestTime - $context.routeKey $context.protocol - $context.status $context.responseLength $context.requestId $context.integrationErrorMessage"
 
   integrations = {
     "GET /start-auth" = {

--- a/terraform/modules/authentication/modules/lambda/main.tf
+++ b/terraform/modules/authentication/modules/lambda/main.tf
@@ -8,6 +8,8 @@ module "lambda" {
   function_name = "${var.prefix}-${var.name}"
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
+  memory_size   = 256
+  timeout       = 30
 
   publish = true
 


### PR DESCRIPTION
### Summary

This fixes the complete-auth lambda that was crashing because it exceeded it's timeout.

### How to test
Steps to test the changes you made:
1. Connect your Discord account using `https://discord-bot-develop.technicie.nl/start-auth?discord-user=<discord-id>`
