### PR TITLE
Add autoremove functionality for the help command

### DIFF
--- a/bot/core/bot.py
+++ b/bot/core/bot.py
@@ -1,12 +1,13 @@
 from discord.ext import commands
 from common.thalia_oauth import get_backend_oauth_client
+from .help import ThaliaHelpCommand
 
 
 class ThaliaBot(commands.Bot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.thalia_client = None
-        self.help_command = commands.DefaultHelpCommand(dm_help=True)
+        self.help_command = ThaliaHelpCommand()
 
     async def connect(self, *args, **kwargs):
         self.thalia_client = await get_backend_oauth_client()

--- a/bot/core/help.py
+++ b/bot/core/help.py
@@ -1,0 +1,14 @@
+from discord.ext.commands import DefaultHelpCommand
+
+
+class ThaliaHelpCommand(DefaultHelpCommand):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, dm_help=True, **kwargs)
+
+    async def prepare_help_command(self, ctx, command):
+        try:
+            await ctx.message.delete()
+        except:
+            # ignore
+            pass
+        await super().prepare_help_command(ctx, command)


### PR DESCRIPTION

### Summary

Add auto remove functionality for the help command which deletes any help command in the guild's channels to keep them clean.

### How to test
Steps to test the changes you made:
1. Run the bot
2. Execute `!help` in your test server
