### PR TITLE
Add linting to dev.py and run.py

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -61,7 +61,7 @@
         
           - name: Run pylint
             run: |
-              pylint dev.py run.py bot authentication common
+              pylint bot authentication common
       terraform:
         strategy:
           fail-fast: false

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -61,7 +61,7 @@
         
           - name: Run pylint
             run: |
-              pylint bot authentication common
+              pylint dev.py run.py bot authentication common
       terraform:
         strategy:
           fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 requirements.txt
 *.pyc
+.idea
 
+bot.log
 .terraform/
 *.tfstate
 *.tfstate.backup

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 requirements.txt
 *.pyc
-.idea
 
-bot.log
 .terraform/
 *.tfstate
 *.tfstate.backup

--- a/dev.py
+++ b/dev.py
@@ -8,15 +8,17 @@ def file_filter(name):
     return (not name.startswith(".")) and (not name.endswith(".swp"))
 
 
-def file_times(path):
-    for top_level in filter(file_filter, os.listdir(path)):
+def file_times(filepath):
+    for top_level in filter(file_filter, os.listdir(filepath)):
+        # pylint: disable=unused-variable
         for root, dirs, files in os.walk(top_level):
             for file in filter(file_filter, files):
                 yield os.stat(os.path.join(root, file)).st_mtime
+        # pylint: enable=unused-variable
 
 
-def print_stdout(process):
-    stdout = process.stdout
+def print_stdout(current_process):
+    stdout = current_process.stdout
     if stdout is not None:
         print(stdout)
 

--- a/dev.py
+++ b/dev.py
@@ -32,11 +32,12 @@ path = "."
 # How often we check the filesystem for changes (in seconds)
 wait = 1
 
-# The process to auto reload
+# The process to autoreload
 process = subprocess.Popen("poetry run python " + command, shell=True)
 
 # The current maximum file modified time under the watched directory
 last_mtime = max(file_times(path))
+
 
 while True:
     max_mtime = max(file_times(path))

--- a/dev.py
+++ b/dev.py
@@ -17,7 +17,7 @@ def file_times(path):
 
 def print_stdout(process):
     stdout = process.stdout
-    if stdout != None:
+    if stdout is not None:
         print(stdout)
 
 
@@ -30,12 +30,11 @@ path = "."
 # How often we check the filesystem for changes (in seconds)
 wait = 1
 
-# The process to autoreload
+# The process to auto reload
 process = subprocess.Popen("poetry run python " + command, shell=True)
 
 # The current maximum file modified time under the watched directory
 last_mtime = max(file_times(path))
-
 
 while True:
     max_mtime = max(file_times(path))


### PR DESCRIPTION
chore: linting to dev.py and run.py files in root dir.
<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
changed the linting command in .github/workflows/linting.yml to make sure it also lints ./dev.py and ./run.py
