### PR TITLE
Add automatic member role sync

### DIFF
--- a/authentication/complete-auth-lambda/index.py
+++ b/authentication/complete-auth-lambda/index.py
@@ -2,9 +2,9 @@ import json
 import base64
 import asyncio
 from common.thalia_oauth import get_oauth2_client, TOKEN_URL
-from common.thalia_api import get_authenticated_member
+from common.thalia_api import get_authenticated_member, get_membergroups
 from common.ddb import write_user
-from common.discord_helper import get_client, sync_member, DISCORD_GUILD_ID
+from common.discord_helper import get_client, sync_members, DISCORD_GUILD_ID
 from common.bot_logger import get_logger
 
 loop = asyncio.get_event_loop()
@@ -35,8 +35,14 @@ async def async_handle(event):
             discord_client = await get_client()
             guild = await discord_client.fetch_guild(DISCORD_GUILD_ID)
             member = await guild.fetch_member(state["discord_user"])
-            await sync_member(thalia_data, member, guild)
-            await member.send(f"Your account has been connected. Welcome to the Thalia Discord {thalia_data['display_name']}!")
+            thalia_data["discord"] = state["discord_user"]
+            membergroups = await get_membergroups(client)
+
+            await sync_members({thalia_data["pk"]: thalia_data}, membergroups, guild)
+
+            await member.send(
+                f"Your account has been connected. Welcome to the Thalia Discord {thalia_data['display_name']}!"
+            )
         except Exception as e:
             logger.exception("Error during Discord sync")
 

--- a/bot/cogs/member.py
+++ b/bot/cogs/member.py
@@ -1,17 +1,23 @@
 import os
 
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
 
 from common.bot_logger import get_logger
+<<<<<<< HEAD
 from common.ddb import get_user_by_discord_id
 from common.thalia_api import get_member_by_id
 from common.discord_helper import DISCORD_GUILD_ID, sync_member
 from common.helper_functions import reply_and_delete
+=======
+from common.ddb import get_user_by_discord_id, get_discord_users_by_thalia_ids
+from common.thalia_api import get_member_by_id, get_members, get_membergroups
+from common.discord_helper import DISCORD_GUILD_ID, sync_members
+>>>>>>> Add automatic member role sync
 
 logger = get_logger(__name__)
 
-CONNECT_DOMAIN_NAME = f"{os.getenv('DOMAIN_NAME')}start-auth"
+CONNECT_DOMAIN_NAME = f"{os.getenv('DOMAIN_NAME')}"
 
 
 class MemberCog(commands.Cog, name="Member management"):
@@ -69,14 +75,15 @@ class MemberCog(commands.Cog, name="Member management"):
             user_data = await get_user_by_discord_id(ctx.author.id)
 
             if user_data:
-                thalia_data = await get_member_by_id(
+                member = await get_member_by_id(
                     self.bot.thalia_client, user_data["thalia_user_id"]
                 )
+                member["discord"] = ctx.author.id
+                membergroups = await get_membergroups(self.bot.thalia_client)
 
                 guild = discord.utils.get(self.bot.guilds, id=DISCORD_GUILD_ID)
-                discord_user = guild.get_member(ctx.author.id)
 
-                await sync_member(thalia_data, discord_user, guild)
+                await sync_members({member["pk"]: member}, membergroups, guild)
                 await reply_and_delete(
                     ctx, "Your user data has been synced successfully"
                 )
@@ -87,6 +94,34 @@ class MemberCog(commands.Cog, name="Member management"):
                 "Error: Could not 'sync', invoked by: 'ctx.author=%s'", ctx.author
             )
             await reply_and_delete(ctx, "Sorry, something went wrong.")
+
+    @tasks.loop(minutes=30)
+    async def full_sync_loop(self):
+        guild = discord.utils.get(self.bot.guilds, id=DISCORD_GUILD_ID)
+
+        members = {
+            member["pk"]: member for member in await get_members(self.bot.thalia_client)
+        }
+        membergroups = await get_membergroups(self.bot.thalia_client)
+
+        user_table = await get_discord_users_by_thalia_ids(
+            [str(m) for m in members.keys()]
+        )
+
+        for record in user_table:
+            members[int(record["thalia_user_id"])]["discord"] = int(
+                record["discord_user_id"]
+            )
+
+        await sync_members(members, membergroups, guild)
+
+    @commands.is_owner()
+    @member.command(help="Triggers a full sync of all members")
+    async def fullsync(self, ctx):
+        await reply_and_delete(
+            ctx, "Full sync triggered"
+        )
+        await self.full_sync_loop()
 
 
 def setup(bot):

--- a/bot/cogs/member.py
+++ b/bot/cogs/member.py
@@ -1,19 +1,11 @@
 import os
 
-import discord
-from discord.ext import commands, tasks
+from discord.ext import commands
 
 from common.bot_logger import get_logger
-<<<<<<< HEAD
 from common.ddb import get_user_by_discord_id
 from common.thalia_api import get_member_by_id
-from common.discord_helper import DISCORD_GUILD_ID, sync_member
 from common.helper_functions import reply_and_delete
-=======
-from common.ddb import get_user_by_discord_id, get_discord_users_by_thalia_ids
-from common.thalia_api import get_member_by_id, get_members, get_membergroups
-from common.discord_helper import DISCORD_GUILD_ID, sync_members
->>>>>>> Add automatic member role sync
 
 logger = get_logger(__name__)
 
@@ -68,60 +60,6 @@ class MemberCog(commands.Cog, name="Member management"):
             await reply_and_delete(
                 ctx, "Note: Your Discord tag has already been connected"
             )
-
-    @member.command(help="Triggers a sync of your member information")
-    async def sync(self, ctx):
-        try:
-            user_data = await get_user_by_discord_id(ctx.author.id)
-
-            if user_data:
-                member = await get_member_by_id(
-                    self.bot.thalia_client, user_data["thalia_user_id"]
-                )
-                member["discord"] = ctx.author.id
-                membergroups = await get_membergroups(self.bot.thalia_client)
-
-                guild = discord.utils.get(self.bot.guilds, id=DISCORD_GUILD_ID)
-
-                await sync_members({member["pk"]: member}, membergroups, guild)
-                await reply_and_delete(
-                    ctx, "Your user data has been synced successfully"
-                )
-            else:
-                await reply_and_delete(ctx, "You have no connected Thalia account")
-        except:
-            logger.exception(
-                "Error: Could not 'sync', invoked by: 'ctx.author=%s'", ctx.author
-            )
-            await reply_and_delete(ctx, "Sorry, something went wrong.")
-
-    @tasks.loop(minutes=30)
-    async def full_sync_loop(self):
-        guild = discord.utils.get(self.bot.guilds, id=DISCORD_GUILD_ID)
-
-        members = {
-            member["pk"]: member for member in await get_members(self.bot.thalia_client)
-        }
-        membergroups = await get_membergroups(self.bot.thalia_client)
-
-        user_table = await get_discord_users_by_thalia_ids(
-            [str(m) for m in members.keys()]
-        )
-
-        for record in user_table:
-            members[int(record["thalia_user_id"])]["discord"] = int(
-                record["discord_user_id"]
-            )
-
-        await sync_members(members, membergroups, guild)
-
-    @commands.is_owner()
-    @member.command(help="Triggers a full sync of all members", hidden=True)
-    async def fullsync(self, ctx):
-        await reply_and_delete(
-            ctx, "Full sync triggered"
-        )
-        await self.full_sync_loop()
 
 
 def setup(bot):

--- a/bot/cogs/member.py
+++ b/bot/cogs/member.py
@@ -116,7 +116,7 @@ class MemberCog(commands.Cog, name="Member management"):
         await sync_members(members, membergroups, guild)
 
     @commands.is_owner()
-    @member.command(help="Triggers a full sync of all members")
+    @member.command(help="Triggers a full sync of all members", hidden=True)
     async def fullsync(self, ctx):
         await reply_and_delete(
             ctx, "Full sync triggered"

--- a/bot/cogs/sync.py
+++ b/bot/cogs/sync.py
@@ -1,0 +1,91 @@
+import os
+
+import discord
+from discord.ext import commands, tasks
+
+from common.bot_logger import get_logger
+from common.ddb import get_user_by_discord_id, get_discord_users_by_thalia_ids
+from common.thalia_api import get_member_by_id, get_members, get_membergroups
+from common.discord_helper import DISCORD_GUILD_ID, sync_members
+from common.helper_functions import reply_and_delete
+
+logger = get_logger(__name__)
+
+CONNECT_DOMAIN_NAME = f"{os.getenv('DOMAIN_NAME')}"
+
+
+class SyncCog(commands.Cog, name="Syncing"):
+    def __init__(self, bot):
+        self.bot = bot
+        logger.info("Sync cog initialised")
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.auto_full_sync.start()
+
+    def cog_unload(self):
+        self.auto_full_sync.cancel()
+
+    @commands.group(
+        name="sync",
+        invoke_without_command=True,
+        help="Sync your roles and nickname with the Thalia website",
+    )
+    async def sync(self, ctx):
+        try:
+            user_data = await get_user_by_discord_id(ctx.author.id)
+
+            if user_data:
+                member = await get_member_by_id(
+                    self.bot.thalia_client, user_data["thalia_user_id"]
+                )
+                member["discord"] = ctx.author.id
+                membergroups = await get_membergroups(self.bot.thalia_client)
+
+                guild = discord.utils.get(self.bot.guilds, id=DISCORD_GUILD_ID)
+
+                await sync_members({member["pk"]: member}, membergroups, guild)
+                await reply_and_delete(
+                    ctx, "Your user data has been synced successfully"
+                )
+            else:
+                await reply_and_delete(ctx, "You have no connected Thalia account")
+        except:
+            logger.exception(
+                "Error: Could not 'sync', invoked by: 'ctx.author=%s'", ctx.author
+            )
+            await reply_and_delete(ctx, "Sorry, something went wrong.")
+
+    async def _full_sync(self):
+        guild = discord.utils.get(self.bot.guilds, id=DISCORD_GUILD_ID)
+
+        members = {
+            member["pk"]: member for member in await get_members(self.bot.thalia_client)
+        }
+        membergroups = await get_membergroups(self.bot.thalia_client)
+
+        user_table = await get_discord_users_by_thalia_ids(
+            [str(m) for m in members.keys()]
+        )
+
+        for record in user_table:
+            members[int(record["thalia_user_id"])]["discord"] = int(
+                record["discord_user_id"]
+            )
+
+        await sync_members(members, membergroups, guild)
+
+    @tasks.loop(minutes=30)
+    async def auto_full_sync(self):
+        logger.info("Running periodic member sync")
+        await self._full_sync()
+
+    @commands.is_owner()
+    @sync.command(name="full", help="Triggers a full sync of all members", hidden=True)
+    async def fullsync(self, ctx):
+        await reply_and_delete(ctx, "Full sync triggered")
+        await self._full_sync()
+
+
+def setup(bot):
+    bot.add_cog(SyncCog(bot))

--- a/bot/core/bot.py
+++ b/bot/core/bot.py
@@ -1,3 +1,4 @@
+from discord import Intents
 from discord.ext import commands
 from common.thalia_oauth import get_backend_oauth_client
 from .help import ThaliaHelpCommand
@@ -5,7 +6,9 @@ from .help import ThaliaHelpCommand
 
 class ThaliaBot(commands.Bot):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        intents = Intents.default()
+        intents.members = True
+        super().__init__(*args, intents=intents, **kwargs)
         self.thalia_client = None
         self.help_command = ThaliaHelpCommand()
 

--- a/common/discord_helper.py
+++ b/common/discord_helper.py
@@ -2,10 +2,14 @@ import os
 import discord
 from discord import Client
 
+from common.bot_logger import get_logger
+
+logger = get_logger(__name__)
+
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 DISCORD_GUILD_ID = int(os.getenv("DISCORD_GUILD_ID"))
 EXCLUDES_ROLES = set(
-    ["admin", "moderator", "@everyone", "Thalia Bot", "Thalia Test Bot"]
+    ["Superadmin", "Admin", "Moderator", "@everyone", "Thalia Bot", "Thalia Test Bot"]
 )
 
 
@@ -15,44 +19,39 @@ async def get_client():
     return client
 
 
-def _calculate_roles(user_data):
-    is_committee_chair = False
-    is_society_chair = False
-    is_committee_member = False
+def _calculate_roles(members, membergroups):
+    for member in members.values():
+        members[member["pk"]]["roles"] = {
+            "Connected",
+            members[member["pk"]]["membership_type"].capitalize(),
+        }
 
-    active_achievements = filter(
-        lambda x: x["latest"] is None and x["active"], user_data["achievements"]
-    )
-    active_societies = filter(
-        lambda x: x["latest"] is None and x["active"], user_data["societies"]
-    )
-    roles = set()
+    for membergroup in membergroups:
+        for group_member in membergroup["members"]:
+            if group_member["pk"] in members:
+                if membergroup["type"] == "committee":
+                    members[group_member["pk"]]["roles"].add("Committee Member")
+                elif membergroup["type"] == "society":
+                    members[group_member["pk"]]["roles"].add("Society Member")
+                members[group_member["pk"]]["roles"].add(membergroup["name"])
 
-    if user_data["membership_type"]:
-        roles.add(user_data["membership_type"].capitalize())
+        if (
+            membergroup["type"] == "committee"
+            and membergroup["chair"]
+            and membergroup["chair"]["pk"] in members
+        ):
+            members[membergroup["chair"]["pk"]]["roles"].add("Committee Chair")
+        elif (
+            membergroup["type"] == "society"
+            and membergroup["chair"]
+            and membergroup["chair"]["pk"] in members
+        ):
+            members[membergroup["chair"]["pk"]]["roles"].add("Society Chair")
 
-    for achievement in active_achievements:
-        if "Board" not in achievement["name"]:
-            is_committee_member = True
-            is_committee_chair = achievement["periods"][-1]["chair"]
-        roles.add(achievement["name"])
-
-    for society in active_societies:
-        is_society_chair = society["periods"][-1]["chair"]
-        roles.add(society["name"])
-
-    if is_committee_chair:
-        roles.add("Committee Chair")
-    if is_society_chair:
-        roles.add("Society Chair")
-    if is_committee_member:
-        roles.add("Committee Member")
-
-    return roles
+    return members
 
 
-async def _sync_roles(user_data, member, guild):
-    thalia_roles = _calculate_roles(user_data)
+async def _sync_roles(thalia_roles, member, guild):
     discord_roles = []
 
     for role_name in thalia_roles:
@@ -67,8 +66,8 @@ async def _sync_roles(user_data, member, guild):
     add_roles = list(set(discord_roles) - set(member.roles))
     remove_roles = list(set(syncable_guild_roles) - set(discord_roles))
 
-    await member.add_roles(*add_roles)
-    await member.remove_roles(*remove_roles)
+    await member.add_roles(*add_roles, reason="Automatic sync")
+    await member.remove_roles(*remove_roles, reason="Automatic sync")
 
 
 async def _prune_roles(guild):
@@ -80,10 +79,17 @@ async def _prune_roles(guild):
         await role.delete()
 
 
-async def sync_member(user_data, member, guild):
-    await _sync_roles(user_data, member, guild)
+async def sync_members(members, membergroups, guild):
+    members = _calculate_roles(members, membergroups)
+
+    for member in filter(lambda x: x.get("discord"), members.values()):
+        discord_user = guild.get_member(member["discord"])
+        if not discord_user:
+            discord_user = await guild.fetch_member(member["discord"])
+        try:
+            await _sync_roles(member["roles"], discord_user, guild)
+            await discord_user.edit(nick=member["display_name"])
+        except:
+            logger.exception("Error syncing a member")
+
     await _prune_roles(guild)
-
-    await member.edit(nick=user_data["display_name"])
-
-    return member

--- a/common/thalia_oauth.py
+++ b/common/thalia_oauth.py
@@ -21,7 +21,7 @@ def get_oauth2_client(token=None):
     return AsyncOAuth2Client(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
-        scope="members:read",
+        scope="members:read activemembers:read",
         redirect_uri=REDIRECT_URI,
         code_challenge_method="S256",
         token=token,
@@ -33,7 +33,7 @@ async def get_backend_oauth_client():
     client = AsyncOAuth2Client(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
-        scope="read members:read",
+        scope="read members:read activemembers:read",
         redirect_uri=REDIRECT_URI,
         code_challenge_method="S256",
         update_token=_update_token,

--- a/poetry.lock
+++ b/poetry.lock
@@ -242,7 +242,7 @@ description = "A Python wrapper for the Discord API"
 name = "discord.py"
 optional = false
 python-versions = ">=3.5.3"
-version = "1.4.1"
+version = "1.5.0"
 
 [package.dependencies]
 aiohttp = ">=3.6.0,<3.7.0"
@@ -660,8 +660,8 @@ cryptography = [
     {file = "cryptography-3.1.tar.gz", hash = "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08"},
 ]
 "discord.py" = [
-    {file = "discord.py-1.4.1-py3-none-any.whl", hash = "sha256:98ea3096a3585c9c379209926f530808f5fcf4930928d8cfb579d2562d119570"},
-    {file = "discord.py-1.4.1.tar.gz", hash = "sha256:f9decb3bfa94613d922376288617e6a6f969260923643e2897f4540c34793442"},
+    {file = "discord.py-1.5.0-py3-none-any.whl", hash = "sha256:3acb61fde0d862ed346a191d69c46021e6063673f63963bc984ae09a685ab211"},
+    {file = "discord.py-1.5.0.tar.gz", hash = "sha256:e71089886aa157341644bdecad63a72ff56b44406b1a6467b66db31c8e5a5a15"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},


### PR DESCRIPTION
Closes #1

### Summary

Add automatic member role sync using timed task.

### How to test
Steps to test the changes you made:
1. Run `!member fullsync` as owner of the bot to sync all members
2. Check that the roles are correct
3. Change something
4. Wait the time the task is setup for (time of writing: 30 min)
2. Check that the roles are correct


### Todo

- [x] Prevent changing of protected roles
- [x] Sync roles of members
- [x] Remove roles from users that are no longer in our members list
- [x] Remove roles that have no users