### PR TITLE
display display_name instead of 'Optional' nick

### DIFF
--- a/bot/cogs/groups.py
+++ b/bot/cogs/groups.py
@@ -37,7 +37,7 @@ class GroupCog(commands.Cog, name="Group management"):
                         msg = Embed(title=role.name, colour=0xE62272)
                         for member in role.members:
                             msg.add_field(
-                                name="\u200B", value=str(member.nick), inline=True
+                                name="\u200B", value=str(member.display_name), inline=True
                             )
 
                         await ctx.author.send(embed=msg)


### PR DESCRIPTION
Closes #33

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating poetry, changing the CI settings etc; no production code change

-->

### Summary
Using Member.display_name instead of Member.nick, because Member.nick returns Optional[str], whereas display_name returns Member.nick and otherwise the user's full display_name.

### How to test
Steps to test the changes you made:
1. Reset your nickname in discord
1. Invoke !group getmembers Connected
2. See that you are also listed
