### PR TITLE
Disallow commands for non-connected people

### DIFF
--- a/bot/cogs/dice.py
+++ b/bot/cogs/dice.py
@@ -4,6 +4,7 @@ from typing import Optional
 from discord.ext import commands
 
 from common.bot_logger import get_logger
+from common.discord_helper import is_connected_or_dm
 
 logger = get_logger(__name__)
 
@@ -14,12 +15,14 @@ class DiceCog(commands.Cog, name="Pseudo random values as a service"):
         logger.info("Dice cog initialised")
 
     @commands.command(help="Throw some dice", aliases=["mexx"])
+    @is_connected_or_dm()
     async def dice(self, ctx, amount: Optional[int] = 2, eyes: Optional[int] = 6):
         await ctx.send(
             " and ".join([str(random.randint(1, eyes)) for x in range(amount)])
         )
 
     @commands.command(hidden=True)
+    @is_connected_or_dm()
     async def mexxx(self, ctx):
         choices = ["1", "2"]
         random.shuffle(choices)

--- a/bot/cogs/groups.py
+++ b/bot/cogs/groups.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 from common.bot_logger import get_logger
 from common.helper_functions import reply_and_delete
-from common.discord_helper import DISCORD_GUILD_ID
+from common.discord_helper import DISCORD_GUILD_ID, is_connected_or_dm
 
 logger = get_logger(__name__)
 
@@ -24,6 +24,7 @@ class GroupCog(commands.Cog, name="Group management"):
         await ctx.send_help(self.group)
 
     @group.command(help="Outputs all users with the role given in the argument(s)")
+    @is_connected_or_dm()
     async def getmembers(self, ctx, *args):
         try:
             roles = get(self.bot.guilds, id=DISCORD_GUILD_ID).roles


### PR DESCRIPTION
### Summary
Disallow commands for non-connected people because they do not deserve access

### How to test
Steps to test the changes you made:
1. Do a command without Connected role
2. DM with text that you have no access
3. Add role
4. Get direct response for the command
